### PR TITLE
feat #4 - 회원가입, 로그인 구현

### DIFF
--- a/meong_signal/account/admin.py
+++ b/meong_signal/account/admin.py
@@ -1,3 +1,5 @@
 from django.contrib import admin
+from .models import User
 
-# Register your models here.
+admin.site.register(User)
+

--- a/meong_signal/account/backends.py
+++ b/meong_signal/account/backends.py
@@ -1,0 +1,19 @@
+from django.contrib.auth.backends import BaseBackend
+from django.contrib.auth import get_user_model
+
+class EmailBackend(BaseBackend):
+    def authenticate(self, request, email=None, password=None, **kwargs):
+        UserModel = get_user_model()
+        try:
+            user = UserModel.objects.get(email=email)
+            if user.check_password(password):
+                return user
+        except UserModel.DoesNotExist:
+            return None
+
+    def get_user(self, user_id):
+        UserModel = get_user_model()
+        try:
+            return UserModel.objects.get(pk=user_id)
+        except UserModel.DoesNotExist:
+            return None

--- a/meong_signal/account/backends.py
+++ b/meong_signal/account/backends.py
@@ -1,19 +1,14 @@
-from django.contrib.auth.backends import BaseBackend
 from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
 
-class EmailBackend(BaseBackend):
+class EmailBackend(ModelBackend):
     def authenticate(self, request, email=None, password=None, **kwargs):
         UserModel = get_user_model()
         try:
             user = UserModel.objects.get(email=email)
+        except UserModel.DoesNotExist:
+            return None
+        else:
             if user.check_password(password):
                 return user
-        except UserModel.DoesNotExist:
-            return None
-
-    def get_user(self, user_id):
-        UserModel = get_user_model()
-        try:
-            return UserModel.objects.get(pk=user_id)
-        except UserModel.DoesNotExist:
-            return None
+        return None

--- a/meong_signal/account/models.py
+++ b/meong_signal/account/models.py
@@ -2,32 +2,37 @@ from django.db import models
 from django.contrib.auth.models import BaseUserManager, AbstractBaseUser
 
 class UserManager(BaseUserManager):
-    def create_user(self, email, pwd, **extra_fields):
+    def create_user(self, email, password, **extra_fields):
         if not email:
             raise ValueError('The email field must be set')
+        email = self.normalize_email(email)
         user = self.model(email=email, **extra_fields)
-        user.set_password(pwd)
+        user.set_password(password)
         user.save(using=self._db)
         return user
 
-    def create_superuser(self, email, pwd, **extra_fields):
+    def create_superuser(self, email, password, **extra_fields):
 
         #필요에 따라 주석처리
         extra_fields.setdefault('is_staff', True)
         extra_fields.setdefault('is_superuser', True)
         ######
 
-        return self.create_user(email, pwd, **extra_fields)
+        return self.create_user(email, password, **extra_fields)
 
 class User(AbstractBaseUser):
     email = models.EmailField(max_length=50, unique=True)
     password = models.CharField(max_length=200)
     nickname = models.CharField(max_length=10)
     road_address = models.CharField(max_length=200, null=True) # 도로명주소
+    detail_address = models.CharField(max_length=100, null=True, blank = True)
     meong = models.IntegerField(default=0)
     total_distance = models.DecimalField(max_digits=10, decimal_places=1, default=0)
     total_kilocalories = models.DecimalField(max_digits=10, decimal_places=1, default=0)
     profile_image = models.CharField(max_length=150, null=True, default='../media/user/dafault_user.jpg')
+
+    is_staff = models.BooleanField(default=False)
+    is_superuser = models.BooleanField(default=False)
 
     objects = UserManager()
 
@@ -36,7 +41,8 @@ class User(AbstractBaseUser):
 
     def __str__(self):
         return self.nickname
-    
+
+
     def has_perm(self, perm, obj=None):
         return self.is_superuser
 

--- a/meong_signal/account/serializer.py
+++ b/meong_signal/account/serializer.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from .models import *
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = '__all__'
+

--- a/meong_signal/account/urls.py
+++ b/meong_signal/account/urls.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('signup', views.signup),
+    path('login', views.login),
+]

--- a/meong_signal/account/views.py
+++ b/meong_signal/account/views.py
@@ -2,6 +2,8 @@ from django.shortcuts import render, get_object_or_404
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import update_last_login
 
+import logging
+
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.decorators import api_view, permission_classes, authentication_classes
@@ -13,6 +15,7 @@ from drf_yasg import openapi
 from .models import User
 from .serializer import UserSerializer
 
+logger = logging.getLogger(__name__)
 
 ##########################################
 # api 1 : 회원가입
@@ -57,7 +60,10 @@ def login(request):
     email = request.data.get('email')
     password = request.data.get('password')
 
-    user = authenticate(request, email=email, password=password)
+    logger.info(f"Attempting login with email: {email}")
+
+    user = authenticate(email=email, password=password)
+
 
     if user is None:
         return Response({'status':'401', 'message': '이메일 또는 비밀번호가 일치하지 않습니다.'}, status=status.HTTP_401_UNAUTHORIZED)

--- a/meong_signal/account/views.py
+++ b/meong_signal/account/views.py
@@ -1,3 +1,72 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import update_last_login
 
-# Create your views here.
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.decorators import api_view, permission_classes, authentication_classes
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework_simplejwt.tokens import RefreshToken
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
+from .models import User
+from .serializer import UserSerializer
+
+
+##########################################
+# api 1 : 회원가입
+
+@swagger_auto_schema(
+        method="POST", 
+        tags=["회원 api"],
+        operation_summary="회원가입", 
+        request_body=UserSerializer
+)
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def signup(request):
+    serializer = UserSerializer(data = request.data)
+
+    if serializer.is_valid():
+        serializer.save()
+        return Response({'status':'201','message': 'All data added successfully'}, status=201)
+    return Response({'status':'400','message':serializer.errors}, status=400)
+
+##########################################
+
+##########################################
+# api 2 : 로그인 
+
+@swagger_auto_schema(
+        method="POST", 
+        tags=["account api"],
+        operation_summary="로그인", 
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                'email': openapi.Schema(type=openapi.TYPE_STRING, description='User login Email'),
+                'password': openapi.Schema(type=openapi.TYPE_STRING, description='User password'),
+            }
+        ),
+)
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def login(request):
+
+    email = request.data.get('email')
+    password = request.data.get('password')
+
+    user = authenticate(request, email=email, password=password)
+
+    if user is None:
+        return Response({'status':'401', 'message': '이메일 또는 비밀번호가 일치하지 않습니다.'}, status=status.HTTP_401_UNAUTHORIZED)
+    
+    token = RefreshToken.for_user(user)
+    update_last_login(None, user)
+
+    return Response({'status':'200', 'refresh_token': str(token),
+                    'access_token': str(token.access_token), }, status=status.HTTP_200_OK)
+
+##########################################
+

--- a/meong_signal/meong_signal/settings.py
+++ b/meong_signal/meong_signal/settings.py
@@ -103,8 +103,8 @@ DATABASES = {
 AUTH_USER_MODEL = 'account.User'
 
 AUTHENTICATION_BACKENDS = [
-    'account.backends.EmailBackend',  # 커스텀 인증 백엔드
-    'django.contrib.auth.backends.ModelBackend',  # 기본 인증 백엔드
+    'account.backends.EmailBackend'  # 커스텀 인증 백엔드
+
 ]
 
 # Password validation

--- a/meong_signal/meong_signal/settings.py
+++ b/meong_signal/meong_signal/settings.py
@@ -68,6 +68,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
+
 ROOT_URLCONF = "meong_signal.urls"
 
 TEMPLATES = [
@@ -100,6 +101,11 @@ DATABASES = {
 }
 
 AUTH_USER_MODEL = 'account.User'
+
+AUTHENTICATION_BACKENDS = [
+    'account.backends.EmailBackend',  # 커스텀 인증 백엔드
+    'django.contrib.auth.backends.ModelBackend',  # 기본 인증 백엔드
+]
 
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators

--- a/meong_signal/meong_signal/urls.py
+++ b/meong_signal/meong_signal/urls.py
@@ -1,6 +1,29 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include, re_path
+
+from rest_framework.permissions import AllowAny
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+from django.conf import settings
+from django.conf.urls.static import static
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="meong-signal",
+        default_version='1.1.1',
+        description="감자탕후루 api 문서",
+        terms_of_service="https://www.google.com/policies/terms/"
+    ),
+    public=True,
+    permission_classes=(AllowAny,),
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-]
+    path('account/', include('account.urls')),
+
+    # Swagger url
+    re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #4 

## 📝작업 내용

> 회원가입과 로그인을 구현했습니다. 
> models.py에 도로명 주소 말고 상세주소를 추가 입력받도록 하였습니다. 
> urls.py를 작성하였습니다. 
> serializer를 작성하였습니다. 
> admin 페이지에 user를 등록하였습니다. 


### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/34c2a23a-0ca4-4e48-aee1-25bdb5b9d8ef)

## 💬리뷰 요구사항(선택)

분명 있는데 왜이러는지 ㅁㄹ겠습니다 ㅠ 
저번에는 user 모델에서 username을 로그인 아이디로 사용했는데 
email이 이메일필드라서 authentication 할 때 문제가 생기는가 싶네요. 
그래서 gpt가 하라는대로 backends.py 작성하고 settings.py 조금 작성하였는데, 있으나 없으나 로그인이 안되네요. 

그냥 한마디로 ㅁㅊ겠습니다 
![image](https://github.com/user-attachments/assets/3db428db-b358-4aba-ba3c-004535e0e724)


