### PR TITLE
fix: #31 채팅방이 이미 존재하는 경우 해당 채팅방 정보 return

### DIFF
--- a/meong_signal/chat/views.py
+++ b/meong_signal/chat/views.py
@@ -49,7 +49,13 @@ class ChatRoomList(generics.ListCreateAPIView):
         if not Dog.objects.filter(id=dog_id, user_id=owner_user_id):
             return Response({'error' : '정보와 일치하는 강아지가 없습니다.'})
         
-        return super().create(request, *args, **kwargs)
+        try:
+            # 이미 채팅방 존재하는 경우
+            chat_room = ChatRoom.objects.get(user_user = user_user_id, owner_user = owner_user_id)
+            serializer = self.get_serializer(chat_room)
+            return Response(serializer.data, status=200)
+        except:
+            return super().create(request, *args, **kwargs)
 
 ############################
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#31 

## 📝작업 내용

- 채팅방 생성 시, 채팅방이 이미 존재하는 경우 해당 채팅방 정보 return하도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
